### PR TITLE
Add workflow to auto-deploy images

### DIFF
--- a/.github/workflows/build_and_push_image.yaml
+++ b/.github/workflows/build_and_push_image.yaml
@@ -66,8 +66,9 @@ jobs:
 
       - name: Build and push
         env:
-          IMAGE: "${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}"
+          IMAGE: "${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}"/go-gin
         run: |
+          echo "repo name is ${{ github.event.repository.name }}"
           devbox generate dockerfile --for prod
           echo "generated dockerfile:"
           cat Dockerfile

--- a/.github/workflows/build_and_push_image.yaml
+++ b/.github/workflows/build_and_push_image.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - "main"
-      - "rodrigo/*"
 
 env:
   ID_PROVIDER: projects/744310309265/locations/global/workloadIdentityPools/gha-oidc-pool/providers/gha-oidc-provider
@@ -18,7 +17,7 @@ jobs:
   build-image:
     strategy:
       matrix:
-        project_id: [dev-j3tpk]
+        project_id: [dev-j3tpk, nonprod-j3tpk, prod-j3tpk]
 
     permissions:
       contents: read

--- a/.github/workflows/build_and_push_image.yaml
+++ b/.github/workflows/build_and_push_image.yaml
@@ -68,17 +68,14 @@ jobs:
         env:
           IMAGE: "${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ github.event.repository.name }}"
         run: |
-          echo "docker config"
-          cat ~/.docker/config.json
-          echo "gcloud auth list"
-          gcloud auth list
-          echo "Docker login"
-          docker login us-east4-docker.pkg.dev
-          echo "repo name is ${{ github.event.repository.name }}"
-          devbox generate dockerfile --for prod
-          echo "generated dockerfile:"
-          cat Dockerfile
-          echo "building ${{ env.IMAGE }}..."
-          docker build . -t ${{ env.IMAGE }}:latest
-          echo "built ${{ env.IMAGE }}. now trying to push..."
+          if [ ! -f Dockerfile ]; then
+            devbox generate dockerfile --for prod
+          fi
+          docker build . \
+            --label "repository=${{ github.repository }}" \
+            --label "revision=${{ github.sha }}" \
+            --label "ref=${{ github.ref_name }}" \
+            --label "workflow=${{ github.workflow_ref }}" \
+            -t ${{ env.IMAGE }}:${{ github.sha }}" \
+            -t ${{ env.IMAGE }}:latest
           docker push ${{ env.IMAGE }} --all-tags

--- a/.github/workflows/build_and_push_image.yaml
+++ b/.github/workflows/build_and_push_image.yaml
@@ -76,6 +76,6 @@ jobs:
             --label "revision=${{ github.sha }}" \
             --label "ref=${{ github.ref_name }}" \
             --label "workflow=${{ github.workflow_ref }}" \
-            -t ${{ env.IMAGE }}:${{ github.sha }}" \
+            -t ${{ env.IMAGE }}:${{ github.sha }} \
             -t ${{ env.IMAGE }}:latest
           docker push ${{ env.IMAGE }} --all-tags

--- a/.github/workflows/build_and_push_image.yaml
+++ b/.github/workflows/build_and_push_image.yaml
@@ -1,0 +1,81 @@
+name: build-and-push-image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "main"
+      - "rodrigo/*"
+
+env:
+  ID_PROVIDER: projects/744310309265/locations/global/workloadIdentityPools/gha-oidc-pool/providers/gha-oidc-provider
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  REPOSITORY: github
+  REGION: us-east4
+  REGISTRY: us-east4-docker.pkg.dev
+
+jobs:
+  build-image:
+    strategy:
+      matrix:
+        project_id: [dev-j3tpk]
+
+    permissions:
+      contents: read
+      id-token: write
+
+    env:
+      PROJECT_ID: ${{ matrix.project_id }}
+      SERVICE_ACCOUNT: ext-gha-jetify-examples@${{ matrix.project_id }}.iam.gserviceaccount.com
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure prod is only deployed from main
+        run: |-
+          if [ ${PROJECT_ID} == "prod-j3tpk" ] && [ "${{ github.ref_name }}" != "main" ]; then
+            echo "Cannot deploy to prod from non-main branch"
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup git credentials
+        run: gh auth setup-git
+
+      - name: Authenticate with GCP (via Workload Federation)
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.ID_PROVIDER }}
+          service_account: ${{ env.SERVICE_ACCOUNT }}
+          token_format: access_token
+
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v1"
+        with:
+          project_id: ${{ env.PROJECT_ID }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.work
+          cache: false
+
+      - name: Setup Ko
+        uses: ko-build/setup-ko@v0.7
+
+      - name: Login to Artifact Registry
+        run: |-
+          ko login "${{ env.REGISTRY }}" --username oauth2accesstoken --password "${{ steps.auth.outputs.access_token }}"
+
+      - name: Build and Publish Image
+        env:
+          KO_DOCKER_REPO: "${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}"
+        run: |-
+          ko build -B . \
+            --image-label "repository=${{ github.repository }}" \
+            --image-label "revision=${{ github.sha }}" \
+            --image-label "ref=${{ github.ref_name }}" \
+            --image-label "workflow=${{ github.workflow_ref }}" \
+            --tags "latest"

--- a/.github/workflows/build_and_push_image.yaml
+++ b/.github/workflows/build_and_push_image.yaml
@@ -66,8 +66,14 @@ jobs:
 
       - name: Build and push
         env:
-          IMAGE: "${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/go-gin"
+          IMAGE: "${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ github.event.repository.name }}"
         run: |
+          echo "docker config"
+          cat ~/.docker/config.json
+          echo "gcloud auth list"
+          gcloud auth list
+          echo "Docker login"
+          docker login us-east4-docker.pkg.dev
           echo "repo name is ${{ github.event.repository.name }}"
           devbox generate dockerfile --for prod
           echo "generated dockerfile:"

--- a/.github/workflows/build_and_push_image.yaml
+++ b/.github/workflows/build_and_push_image.yaml
@@ -10,7 +10,7 @@ on:
 env:
   ID_PROVIDER: projects/744310309265/locations/global/workloadIdentityPools/gha-oidc-pool/providers/gha-oidc-provider
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  REPOSITORY: github
+  REPOSITORY: github_public
   REGION: us-east4
   REGISTRY: us-east4-docker.pkg.dev
 
@@ -56,26 +56,18 @@ jobs:
         with:
           project_id: ${{ env.PROJECT_ID }}
 
-      - name: Setup Go
-        uses: actions/setup-go@v5
+      - name: Configure Docker credentials
+        run: gcloud auth configure-docker us-docker.pkg.dev
+
+      - name: Install Devbox
+        uses: jetify-com/devbox-install-action@v0.11.0
         with:
-          go-version-file: go.work
-          cache: false
+          enable-cache: true
 
-      - name: Setup Ko
-        uses: ko-build/setup-ko@v0.7
-
-      - name: Login to Artifact Registry
-        run: |-
-          ko login "${{ env.REGISTRY }}" --username oauth2accesstoken --password "${{ steps.auth.outputs.access_token }}"
-
-      - name: Build and Publish Image
+      - name: Build and push
         env:
-          KO_DOCKER_REPO: "${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}"
-        run: |-
-          ko build -B . \
-            --image-label "repository=${{ github.repository }}" \
-            --image-label "revision=${{ github.sha }}" \
-            --image-label "ref=${{ github.ref_name }}" \
-            --image-label "workflow=${{ github.workflow_ref }}" \
-            --tags "latest"
+          IMAGE: "${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}"
+        run: |
+          devbox generate dockerfile --for prod
+          docker build . -t ${{ env.IMAGE }}:latest
+          docker push ${{ env.IMAGE }} --all-tags

--- a/.github/workflows/build_and_push_image.yaml
+++ b/.github/workflows/build_and_push_image.yaml
@@ -57,7 +57,7 @@ jobs:
           project_id: ${{ env.PROJECT_ID }}
 
       - name: Configure Docker credentials
-        run: gcloud auth configure-docker us-docker.pkg.dev
+        run: gcloud auth configure-docker us-east4-docker.pkg.dev
 
       - name: Install Devbox
         uses: jetify-com/devbox-install-action@v0.11.0
@@ -69,5 +69,9 @@ jobs:
           IMAGE: "${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}"
         run: |
           devbox generate dockerfile --for prod
+          echo "generated dockerfile:"
+          cat Dockerfile
+          echo "building ${{ env.IMAGE }}..."
           docker build . -t ${{ env.IMAGE }}:latest
+          echo "built ${{ env.IMAGE }}. now trying to push..."
           docker push ${{ env.IMAGE }} --all-tags

--- a/.github/workflows/build_and_push_image.yaml
+++ b/.github/workflows/build_and_push_image.yaml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Build and push
         env:
-          IMAGE: "${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}"/go-gin
+          IMAGE: "${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/go-gin"
         run: |
           echo "repo name is ${{ github.event.repository.name }}"
           devbox generate dockerfile --for prod

--- a/.github/workflows/build_and_push_image.yaml
+++ b/.github/workflows/build_and_push_image.yaml
@@ -10,7 +10,7 @@ on:
 env:
   ID_PROVIDER: projects/744310309265/locations/global/workloadIdentityPools/gha-oidc-pool/providers/gha-oidc-provider
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  REPOSITORY: github_public
+  REPOSITORY: github-public
   REGION: us-east4
   REGISTRY: us-east4-docker.pkg.dev
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@
 # Go workspace file
 go.work
 go.work.sum
+
+.idea

--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,13 @@
+{
+  "$schema":  "https://raw.githubusercontent.com/jetify-com/devbox/0.12.0/.schema/devbox.schema.json",
+  "packages": ["go@latest"],
+  "shell": {
+    "init_hook": [
+      "echo 'Welcome to devbox!' > /dev/null"
+    ],
+    "scripts": {
+      "build": "go build ./main.go",
+      "start": "go run ./main.go"
+    }
+  }
+}

--- a/devbox.json
+++ b/devbox.json
@@ -2,9 +2,6 @@
   "$schema":  "https://raw.githubusercontent.com/jetify-com/devbox/0.12.0/.schema/devbox.schema.json",
   "packages": ["go@latest"],
   "shell": {
-    "init_hook": [
-      "echo 'Welcome to devbox!' > /dev/null"
-    ],
     "scripts": {
       "build": "go build ./main.go",
       "start": "go run ./main.go"

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,0 +1,53 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "go@latest": {
+      "last_modified": "2024-07-20T09:11:00Z",
+      "resolved": "github:NixOS/nixpkgs/6e14bbce7bea6c4efd7adfa88a40dac750d80100#go",
+      "source": "devbox-search",
+      "version": "1.22.5",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/05saqcgidraqmn4z82prsp7rbj9hjmwm-go-1.22.5",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/05saqcgidraqmn4z82prsp7rbj9hjmwm-go-1.22.5"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/b97bbxn6kpysysxb8nxn4k39ffxmp4p6-go-1.22.5",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/b97bbxn6kpysysxb8nxn4k39ffxmp4p6-go-1.22.5"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/gdyii59c48s4a8q6w584ccgm95qls3lh-go-1.22.5",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/gdyii59c48s4a8q6w584ccgm95qls3lh-go-1.22.5"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/3v17dij8rvg7q99009swxg52995r7s22-go-1.22.5",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/3v17dij8rvg7q99009swxg52995r7s22-go-1.22.5"
+        }
+      }
+    }
+  }
+}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 )
 
 func main() {
+  // a test comment
 	router := gin.New()
 
 	router.GET("/", root.Root)

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 )
 
 func main() {
-  // a test comment
 	router := gin.New()
 
 	router.GET("/", root.Root)


### PR DESCRIPTION
Build and deploy images to `github-public` upon merges.

Also adds devbox.json to make things easier (build from devbox).

Tested:
https://console.cloud.google.com/artifacts/docker/dev-j3tpk/us-east4/github-public/go-gin